### PR TITLE
Fixing NullReferenceException when accessing certain response types in a TrainAnnouncement

### DIFF
--- a/TrafikverketdotNET/Subs/TrainAnnouncementResponse/Booking.cs
+++ b/TrafikverketdotNET/Subs/TrainAnnouncementResponse/Booking.cs
@@ -11,11 +11,11 @@ namespace TrafikverketdotNET.Subs.TrainAnnouncementResponse
         /// <summary>
         /// Bokningsinformationskod.
         /// </summary>
-        [JsonIgnore] public String Code { get; set; }
+        [JsonIgnore] public String Code => _Code;
         /// <summary>
         /// Bokninginformation, ex: "Vagn 4 obokad".
         /// </summary>
-        [JsonIgnore] public String Description { get; set; }
+        [JsonIgnore] public String Description => _Description;
 
         internal Booking() { }
     }

--- a/TrafikverketdotNET/Subs/TrainAnnouncementResponse/Deviation.cs
+++ b/TrafikverketdotNET/Subs/TrainAnnouncementResponse/Deviation.cs
@@ -11,11 +11,11 @@ namespace TrafikverketdotNET.Subs.TrainAnnouncementResponse
         /// <summary>
         /// Full Orsakskod.
         /// </summary>
-        [JsonIgnore] public String Code { get; set; }
+        [JsonIgnore] public String Code => _Code;
         /// <summary>
         /// Eventuell avvikelse, ex: "Buss ersätter", "Spårändrat", "Kort tåg", "Ej servering" o.s.v.
         /// </summary>
-        [JsonIgnore] public String Description { get; set; }
+        [JsonIgnore] public String Description => _Description;
 
         internal Deviation() { }
     }

--- a/TrafikverketdotNET/Subs/TrainAnnouncementResponse/OtherInformation.cs
+++ b/TrafikverketdotNET/Subs/TrainAnnouncementResponse/OtherInformation.cs
@@ -11,11 +11,11 @@ namespace TrafikverketdotNET.Subs.TrainAnnouncementResponse
         /// <summary>
         /// Kod för övrig annonseringsinformation.
         /// </summary>
-        [JsonIgnore] public String Code { get; set; }
+        [JsonIgnore] public String Code => _Code;
         /// <summary>
         /// Övrig annonseringsinformation, ex. "Trevlig resa!", "Bakre fordon går låst!", "Ingen påstigning".
         /// </summary>
-        [JsonIgnore] public String Description { get; set; }
+        [JsonIgnore] public String Description => _Description;
 
         internal OtherInformation() { }
     }

--- a/TrafikverketdotNET/Subs/TrainAnnouncementResponse/ProductInformation.cs
+++ b/TrafikverketdotNET/Subs/TrainAnnouncementResponse/ProductInformation.cs
@@ -11,11 +11,11 @@ namespace TrafikverketdotNET.Subs.TrainAnnouncementResponse
         /// <summary>
         /// Kod för beskrivning av tåget.
         /// </summary>
-        [JsonIgnore] public String Code { get; set; }
+        [JsonIgnore] public String Code => _Code;
         /// <summary>
         /// Beskrivning av tåget, ex. "Tågkompaniet", "SJ InterCity", "TiB/Tågkomp".
         /// </summary>
-        [JsonIgnore] public String Description { get; set; }
+        [JsonIgnore] public String Description => _Description;
 
         internal ProductInformation() { }
     }

--- a/TrafikverketdotNET/Subs/TrainAnnouncementResponse/Service.cs
+++ b/TrafikverketdotNET/Subs/TrainAnnouncementResponse/Service.cs
@@ -11,11 +11,11 @@ namespace TrafikverketdotNET.Subs.TrainAnnouncementResponse
         /// <summary>
         /// Servicekod.
         /// </summary>
-        [JsonIgnore] public String Code { get; set; }
+        [JsonIgnore] public String Code => _Code;
         /// <summary>
         /// Lite extra utöver produktinformation, ex "Bistro", "Sov-och liggv".
         /// </summary>
-        [JsonIgnore] public String Description { get; set; }
+        [JsonIgnore] public String Description => _Description;
 
         internal Service() { }
     }

--- a/TrafikverketdotNET/Subs/TrainAnnouncementResponse/TrainComposition.cs
+++ b/TrafikverketdotNET/Subs/TrainAnnouncementResponse/TrainComposition.cs
@@ -11,11 +11,11 @@ namespace TrafikverketdotNET.Subs.TrainAnnouncementResponse
         /// <summary>
         /// Tågsammansättningskod
         /// </summary>
-        [JsonIgnore] public String Code { get; set; }
+        [JsonIgnore] public String Code => _Code;
         /// <summary>
         /// Tågsammansättning, ex: "Vagnsordning 7, 6, 5, 4, 2, 1"
         /// </summary>
-        [JsonIgnore] public String Description { get; set; }
+        [JsonIgnore] public String Description => _Description;
 
         internal TrainComposition() { }
     }

--- a/TrafikverketdotNET/TrafikverketdotNET.csproj
+++ b/TrafikverketdotNET/TrafikverketdotNET.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45;net46;net47</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45;net46;net47;net7.0</TargetFrameworks>
     <Version>1.2.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>BloodfallenTear</Company>


### PR DESCRIPTION
Hi, I started using your library recently but  the strings returned when trying to access ProductInformation, Deviation, Booking, OtherInformation, Service or TrainComposition parts of a TrainAnnouncement response were either empty or just null. I seem to have tracked down the issue to the fact that none of the public attributes for those classes had implemented getters and setters. I simply mapped all those attributes to their corresponding internal fields as was already done on other classes in a TrainAnnouncement. This seems to have fixed the issue and the results are now being accessed fine. 

I also added .NET 7 as a target framework so i could actually run the library in my own code. There seems to be no compatibility issues compiling for .NET 7, but i haven't tested this extensively at all. Great work on the library, made my life a lot easier and I hope this little fix helps, even though this project hasn't been updated for a while.